### PR TITLE
Make exported symbols on exports enumerable

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -12,6 +12,7 @@
  * @type {Object}
  */
 Object.defineProperty(exports, 'cli', {
+  enumerable: true,
   value: require('./cli')
 });
 
@@ -20,6 +21,7 @@ Object.defineProperty(exports, 'cli', {
  * @type {Object}
  */
 Object.defineProperty(exports, 'npm', {
+  enumerable: true,
   value: require('./npm')
 });
 
@@ -28,5 +30,6 @@ Object.defineProperty(exports, 'npm', {
  * @type {Object}
  */
 Object.defineProperty(exports, 'syslog', {
+  enumerable: true,
   value: require('./syslog')
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,17 @@
+export as namespace TripleBeam;
+
+export const LEVEL: unique symbol;
+export const MESSAGE: unique symbol;
+export const SPLAT: unique symbol;
+export const configs: Configs;
+
+export interface Config {
+    readonly levels: { [k: string]: number };
+    readonly colors: { [k: string]: string };
+}
+
+export interface Configs {
+    readonly cli: Config;
+    readonly npm: Config;
+    readonly syslog: Config;
+}

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@
  * @type {Symbol}
  */
 Object.defineProperty(exports, 'LEVEL', {
+  enumerable: true,
   value: Symbol.for('level')
 });
 
@@ -21,6 +22,7 @@ Object.defineProperty(exports, 'LEVEL', {
  * @type {Symbol}
  */
 Object.defineProperty(exports, 'MESSAGE', {
+  enumerable: true,
   value: Symbol.for('message')
 });
 
@@ -32,6 +34,7 @@ Object.defineProperty(exports, 'MESSAGE', {
  * @type {Symbol}
  */
 Object.defineProperty(exports, 'SPLAT', {
+  enumerable: true,
   value: Symbol.for('splat')
 });
 
@@ -42,5 +45,6 @@ Object.defineProperty(exports, 'SPLAT', {
  * @type {Object}
  */
 Object.defineProperty(exports, 'configs', {
+  enumerable: true,
   value: require('./config')
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "triple-beam",
-  "version": "1.4.1",
+  "name": "@orbit-online/triple-beam",
+  "version": "1.4.2-bun-fix2",
   "description": "Definitions of levels for logging purposes & shareable Symbol constants.",
   "main": "index.js",
   "scripts": {
@@ -28,8 +28,8 @@
   },
   "homepage": "https://github.com/winstonjs/triple-beam#readme",
   "devDependencies": {
-    "assume": "^2.0.1",
     "@dabh/eslint-config-populist": "^5.0.0",
+    "assume": "^2.0.1",
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "typescript": "^5.1.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orbit-online/triple-beam",
-  "version": "1.4.2-bun-fix2",
+  "version": "1.4.2-bun-fix3",
   "description": "Definitions of levels for logging purposes & shareable Symbol constants.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.2-bun-fix2",
   "description": "Definitions of levels for logging purposes & shareable Symbol constants.",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "lint": "eslint config/*.js index.js --resolve-plugins-relative-to ./node_modules/@dabh/eslint-config-populist",
     "pretest": "npm run lint",


### PR DESCRIPTION
For reference: https://github.com/oven-sh/bun/issues/4432#issuecomment-1701796961

Currently bun cannot import triple-beam symbols becaause of this issue.

It's probably a good idea to make the exports enumerable anyways.